### PR TITLE
Fix TR issue replacing it with cut

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -13,14 +13,14 @@ cp /etc/nginx/routes.conf.template /etc/nginx/routes.conf
 
 fqdn=$(grep search /etc/resolv.conf | awk '{print $2}' | head -1)
 
-if [ -z "$fqdn" ]; then
+if [ -z "$fqdn" ] || [ "$fqdn" = "." ]; then
   fqdn='local'
 fi
 
 for var in $(env)
 do
   ENV_VAR_KEY="\$$(echo "$var" | tr "=" " " | awk '{print $1}')"
-  ENV_VAR_VALUE=$(echo "$var" | tr "$ENV_VAR_KEY=" " " | awk '{print $1}')
+  ENV_VAR_VALUE=$(echo "$var" | cut -d= -f2-)
 
   case "$ENV_VAR_VALUE" in
   *.*)


### PR DESCRIPTION
Prviously if we add a common character between the variable key and variable value. The ENV_VAR_VALUE wasn't the expected one 

After the fix runing the following command locally : 
```
sudo docker build -t nginx-gateway .
sudo docker run -p 8080:80 -e SIMULATOR_API_V2=app-test-v2 -e SIMULATOR_API_V3=app-test-v3 -e SIMULATOR_API_V4=app-z04776e76-api-v nginx-gateway
```
gave me the expected following result : 
```
location ~* ^/v4/(.*)$ {
    proxy_pass http://app-z04776e76-api-v.local:8000$request_uri;
}--------- EOF GENERTED ROUTES.CONF ---------
```